### PR TITLE
Added patch to cluster-autoscaler configmaps

### DIFF
--- a/addons/autoscaler.yaml
+++ b/addons/autoscaler.yaml
@@ -168,6 +168,7 @@ rules:
   - delete
   - get
   - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fixes a permissions issue when scaling down.