### PR TITLE
Update cluster

### DIFF
--- a/addons/autoscaler.yaml
+++ b/addons/autoscaler.yaml
@@ -77,6 +77,7 @@ rules:
   - endpoints
   verbs:
   - create
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -158,12 +159,6 @@ rules:
   - configmaps
   verbs:
   - create
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - patch
 - apiGroups:
   - ""
   resources:

--- a/addons/autoscaler.yaml
+++ b/addons/autoscaler.yaml
@@ -161,6 +161,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   resourceNames:
   - cluster-autoscaler-status

--- a/main.tf
+++ b/main.tf
@@ -372,6 +372,10 @@ resource "aws_autoscaling_group" "nodes" {
   }]
 
   tags = ["${var.tags2}"]
+
+  lifecycle {
+    ignore_changes = ["desired_capacity"]
+  }  
 }
 
 #####


### PR DESCRIPTION
I mis-read the error message, on the last PR. I have just done another scaling operation and got this error message. I don't think this get raised everytime. 

I think this is the correct fix.

I have also included a small fix to correct overwriting the current autoscaling group capacity.

```
E0309 00:42:01.372859       1 event.go:200] Server rejected event 
'&amp;v1.Event{
TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, 
ObjectMeta:v1.ObjectMeta{
Name:"cluster-autoscaler-status.151a16635f94ea2f", 
GenerateName:"", Namespace:"kube-system", 
SelfLink:"", UID:"",
 ResourceVersion:"4760077", 
Generation:0, 
CreationTimestamp:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, 
InvolvedObject:v1.ObjectReference{
Kind:"ConfigMap", 
Namespace:"kube-system", 
Name:"cluster-autoscaler-status", 
UID:"8b7ecae7-2322-11e8-a8f0-02a9a02d1274", APIVersion:"v1", ResourceVersion:"4773065", FieldPath:""}, 
Reason:"ScaledUpGroup", 
Message:"Scale-up: group staging-aws-kubernetes-nodes size set to 2", Source:v1.EventSource{Component:"cluster-autoscaler", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{sec:63656149240, nsec:0, loc:(*time.Location)(0x5618b60)}}, LastTimestamp:v1.Time{Time:time.Time{sec:63656152921, nsec:371421951, loc:(*time.Location)(0x5618b60)}}, Count:2, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}':
 'events "cluster-autoscaler-status.151a16635f94ea2f" is forbidden: 
User "system:serviceaccount:kube-system:cluster-autoscaler" cannot patch events in the namespace "kube-system"' (will not retry!)
```

