### PR TITLE
error on install awscli

### DIFF
--- a/scripts/init-aws-kubernetes-master.sh
+++ b/scripts/init-aws-kubernetes-master.sh
@@ -30,8 +30,8 @@ DNS_NAME=$(echo "$DNS_NAME" | tr 'A-Z' 'a-z')
 
 # Install AWS CLI client
 yum install -y epel-release
-yum install -y python2-pip
-pip install awscli --upgrade
+yum install -y python3-pip
+pip3 install --upgrade awscli
 
 ########################################
 ########################################

--- a/scripts/init-aws-kubernetes-master.sh
+++ b/scripts/init-aws-kubernetes-master.sh
@@ -105,7 +105,7 @@ systemctl restart containerd
 
 ########################################
 ########################################
-# Install Kubernetes compoenents
+# Install Kubernetes components
 ########################################
 ########################################
 sudo cat <<EOF > /etc/yum.repos.d/kubernetes.repo
@@ -115,11 +115,11 @@ baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kubelet kubeadm kubectl
 EOF
 
-yum install -y kubelet-$KUBERNETES_VERSION kubeadm-$KUBERNETES_VERSION kubernetes-cni
+yum install -y kubelet-$KUBERNETES_VERSION kubeadm-$KUBERNETES_VERSION kubernetes-cni --disableexcludes=kubernetes
 
 # Start services
 systemctl enable kubelet

--- a/scripts/init-aws-kubernetes-node.sh
+++ b/scripts/init-aws-kubernetes-node.sh
@@ -84,7 +84,7 @@ systemctl restart containerd
 
 ########################################
 ########################################
-# Install Kubernetes compoenents
+# Install Kubernetes components
 ########################################
 ########################################
 sudo cat <<EOF > /etc/yum.repos.d/kubernetes.repo
@@ -94,11 +94,11 @@ baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kubelet kubeadm kubectl
 EOF
 
-yum install -y kubelet-$KUBERNETES_VERSION kubeadm-$KUBERNETES_VERSION kubernetes-cni
+yum install -y kubelet-$KUBERNETES_VERSION kubeadm-$KUBERNETES_VERSION kubernetes-cni --disableexcludes=kubernetes
 
 # Start services
 systemctl enable kubelet


### PR DESCRIPTION
```bash
cat /var/log/init-aws-kubernetes-master.log
...

########################################
########################################
# Tag subnets
########################################
########################################
for SUBNET in $AWS_SUBNETS
do
  aws ec2 create-tags --resources $SUBNET --tags Key=kubernetes.io/cluster/$CLUSTER_NAME,Value=shared --region $AWS_REGION
done
Traceback (most recent call last):
  File "/usr/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/usr/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 69, in main
    driver = create_clidriver()
  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 79, in create_clidriver
    event_hooks=session.get_component('event_emitter'))
  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 44, in load_plugins
    modules = _import_plugins(plugin_mapping)
  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 61, in _import_plugins
    module = __import__(path, fromlist=[module])
  File "/usr/lib/python2.7/site-packages/awscli/handlers.py", line 27, in <module>
    from awscli.customizations.cloudformation import initialize as cloudformation_init
  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/__init__.py", line 13, in <module>
    from awscli.customizations.cloudformation.package import PackageCommand
  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/package.py", line 26, in <module>
    from awscli.customizations.s3uploader import S3Uploader
  File "/usr/lib/python2.7/site-packages/awscli/customizations/s3uploader.py", line 22, in <module>
    from s3transfer.manager import TransferManager
  File "/usr/lib/python2.7/site-packages/s3transfer/__init__.py", line 134, in <module>
    import concurrent.futures
ImportError: No module named concurrent.futures
```