### PR TITLE
Fixed error on install awscli

### DIFF
--- a/scripts/init-aws-kubernetes-master.sh
+++ b/scripts/init-aws-kubernetes-master.sh
@@ -30,8 +30,8 @@ DNS_NAME=$(echo "$DNS_NAME" | tr 'A-Z' 'a-z')
 
 # Install AWS CLI client
 yum install -y epel-release
-yum install -y python2-pip
-pip install awscli --upgrade
+yum install -y python3-pip
+pip3 install --upgrade awscli
 
 ########################################
 ########################################


### PR DESCRIPTION
	* get an error when installing awscli on the
	  master node with pip, updated to documentation, pip version 3
	  https://docs.aws.amazon.com/cli/latest/userguide/install-linux-al2017.html


```bash
cat /var/log/init-aws-kubernetes-master.log
...

########################################
########################################
# Tag subnets
########################################
########################################
for SUBNET in $AWS_SUBNETS
do
  aws ec2 create-tags --resources $SUBNET --tags Key=kubernetes.io/cluster/$CLUSTER_NAME,Value=shared --region $AWS_REGION
done
Traceback (most recent call last):
  File "/usr/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/usr/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 69, in main
    driver = create_clidriver()
  File "/usr/lib/python2.7/site-packages/awscli/clidriver.py", line 79, in create_clidriver
    event_hooks=session.get_component('event_emitter'))
  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 44, in load_plugins
    modules = _import_plugins(plugin_mapping)
  File "/usr/lib/python2.7/site-packages/awscli/plugin.py", line 61, in _import_plugins
    module = __import__(path, fromlist=[module])
  File "/usr/lib/python2.7/site-packages/awscli/handlers.py", line 27, in <module>
    from awscli.customizations.cloudformation import initialize as cloudformation_init
  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/__init__.py", line 13, in <module>
    from awscli.customizations.cloudformation.package import PackageCommand
  File "/usr/lib/python2.7/site-packages/awscli/customizations/cloudformation/package.py", line 26, in <module>
    from awscli.customizations.s3uploader import S3Uploader
  File "/usr/lib/python2.7/site-packages/awscli/customizations/s3uploader.py", line 22, in <module>
    from s3transfer.manager import TransferManager
  File "/usr/lib/python2.7/site-packages/s3transfer/__init__.py", line 134, in <module>
    import concurrent.futures
ImportError: No module named concurrent.futures
```